### PR TITLE
Add the ability to add a bank account

### DIFF
--- a/lib/spreedly/payment_methods/payment_method.rb
+++ b/lib/spreedly/payment_methods/payment_method.rb
@@ -1,9 +1,9 @@
+# frozen_string_literal: true
+
 require 'time'
 
 module Spreedly
-
   class PaymentMethod < Model
-
     include ErrorsParser
 
     field :email, :storage_state, :data, :payment_method_type
@@ -17,29 +17,27 @@ module Spreedly
     def self.new_from(xml_doc)
       case xml_doc.at_xpath('.//payment_method_type').inner_text
       when 'credit_card'
-        return CreditCard.new(xml_doc)
+        CreditCard.new(xml_doc)
       when 'paypal'
-        return Paypal.new(xml_doc)
+        Paypal.new(xml_doc)
       when 'sprel'
-        return Sprel.new(xml_doc)
+        Sprel.new(xml_doc)
       when 'bank_account'
-        return BankAccount.new(xml_doc)
+        BankAccount.new(xml_doc)
       when 'third_party_token'
-        return ThirdPartyToken.new(xml_doc)
+        ThirdPartyToken.new(xml_doc)
       end
     end
 
     def self.new_list_from(xml_doc)
       payment_methods = xml_doc.xpath('.//payment_methods/payment_method')
       payment_methods.map do |each|
-        self.new_from(each)
+        new_from(each)
       end
     end
 
     def valid?
       @errors.empty?
     end
-
   end
-
 end

--- a/test/remote/remote_add_bank_account_test.rb
+++ b/test/remote/remote_add_bank_account_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RemoteAddBankAccountTest < Test::Unit::TestCase
+  def setup
+    @environment = Spreedly::Environment.new(remote_test_environment_key, remote_test_access_secret)
+  end
+
+  def test_invalid_login
+    assert_invalid_login do |environment|
+      environment.add_bank_account(account_deets)
+    end
+  end
+
+  def test_failed_with_validation_errors
+    error = assert_raises(Spreedly::TransactionCreationError) do
+      @environment.add_bank_account(account_deets(last_name: '', first_name: ''))
+    end
+
+    expected_errors = [
+      { attribute: 'full_name', key: 'errors.blank', message: "Full name can't be blank" }
+    ]
+
+    assert_equal expected_errors, error.errors
+    assert_equal "Full name can't be blank", error.message
+  end
+
+  def test_payment_required
+    assert_raise_with_message(Spreedly::PaymentRequiredError, "Your environment (#{remote_test_environment_key}) has not been activated for real transactions with real payment methods. If you're using a Test Gateway you can *ONLY* use Test payment methods - ( https://docs.spreedly.com/test-data). All other credit card numbers are considered real credit cards; real credit cards are not allowed when using a Test Gateway.") do
+      @environment.add_bank_account(account_deets(bank_routing_number: '123'))
+    end
+  end
+
+  def test_successful_add_bank_account
+    t = @environment.add_bank_account(account_deets)
+
+    assert t.succeeded?
+    assert_equal 'Stein', t.payment_method.last_name
+    assert !t.retained
+    assert_equal 'cached', t.payment_method.storage_state
+  end
+
+  def test_successfully_retain_on_create
+    t = @environment.add_bank_account(account_deets(retained: true))
+
+    assert t.succeeded?
+    assert t.retained
+    assert_equal 'retained', t.payment_method.storage_state
+  end
+
+  private
+
+  def account_deets(options = {})
+    {
+      bank_routing_number: '021000021', bank_account_number: '9876543210',
+      bank_account_type: 'checking', bank_account_holder_type: 'personal',
+      last_name: 'Stein', first_name: 'Alessandro'
+    }.merge(options)
+  end
+end

--- a/test/remote/remote_add_credit_card_test.rb
+++ b/test/remote/remote_add_credit_card_test.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteAddCreditCardTest < Test::Unit::TestCase
-
   def setup
     @environment = Spreedly::Environment.new(remote_test_environment_key, remote_test_access_secret)
   end
@@ -18,8 +19,8 @@ class RemoteAddCreditCardTest < Test::Unit::TestCase
     end
 
     expected_errors = [
-      { attribute: "first_name", key: "errors.blank", message: "First name can't be blank" },
-      { attribute: "last_name", key: "errors.blank", message: "Last name can't be blank" }
+      { attribute: 'first_name', key: 'errors.blank', message: "First name can't be blank" },
+      { attribute: 'last_name', key: 'errors.blank', message: "Last name can't be blank" }
     ]
 
     assert_equal expected_errors, error.errors
@@ -27,7 +28,7 @@ class RemoteAddCreditCardTest < Test::Unit::TestCase
   end
 
   def test_payment_required
-    assert_raise_with_message(Spreedly::PaymentRequiredError, "Your environment (R7lHscqcYkZeDGGbthKp6GKMu15) has not been activated for real transactions with real payment methods. If you're using a Test Gateway you can *ONLY* use Test payment methods - ( https://docs.spreedly.com/test-data). All other credit card numbers are considered real credit cards; real credit cards are not allowed when using a Test Gateway.") do
+    assert_raise_with_message(Spreedly::PaymentRequiredError, "Your environment (#{remote_test_environment_key}) has not been activated for real transactions with real payment methods. If you're using a Test Gateway you can *ONLY* use Test payment methods - ( https://docs.spreedly.com/test-data). All other credit card numbers are considered real credit cards; real credit cards are not allowed when using a Test Gateway.") do
       @environment.add_credit_card(card_deets(number: '343'))
     end
   end
@@ -51,20 +52,19 @@ class RemoteAddCreditCardTest < Test::Unit::TestCase
   end
 
   def test_successfull_add_using_full_name
-    t = @environment.add_credit_card(number: '5555555555554444', month: 1, year: 2023, full_name: "Kvothe Jones")
+    t = @environment.add_credit_card(number: '5555555555554444', month: 1, year: 2023, full_name: 'Kvothe Jones')
     assert t.succeeded?
-    assert_equal "Kvothe", t.payment_method.first_name
-    assert_equal "Jones", t.payment_method.last_name
-    assert_equal "Kvothe Jones", t.payment_method.full_name
+    assert_equal 'Kvothe', t.payment_method.first_name
+    assert_equal 'Jones', t.payment_method.last_name
+    assert_equal 'Kvothe Jones', t.payment_method.full_name
   end
 
-
   private
+
   def card_deets(options = {})
     {
       email: 'perrin@wot.com', number: '5555555555554444', month: 1, year: 2023,
-      last_name: 'Aybara', first_name: 'Perrin', data: "occupation: Blacksmith"
+      last_name: 'Aybara', first_name: 'Perrin', data: 'occupation: Blacksmith'
     }.merge(options)
   end
-
 end

--- a/test/remote/remote_add_gateway_test.rb
+++ b/test/remote/remote_add_gateway_test.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteAddGatewayTest < Test::Unit::TestCase
-
   def setup
     @environment = Spreedly::Environment.new(remote_test_environment_key, remote_test_access_secret)
   end
@@ -13,22 +14,21 @@ class RemoteAddGatewayTest < Test::Unit::TestCase
   end
 
   def test_non_existent_gateway_type
-    assert_raise_with_message(Spreedly::TransactionCreationError, "The gateway_type parameter is invalid.") do
+    assert_raise_with_message(Spreedly::TransactionCreationError, 'The gateway_type parameter is invalid.') do
       @environment.add_gateway(:non_existent)
     end
   end
 
   def test_add_test_gateway
     gateway = @environment.add_gateway(:test)
-    assert_equal "test", gateway.gateway_type
-    assert_equal "retained", gateway.state
-    assert_equal "Spreedly Test", gateway.name
+    assert_equal 'test', gateway.gateway_type
+    assert_equal 'retained', gateway.state
+    assert_equal 'Spreedly Test', gateway.name
   end
 
   def test_need_active_account
-    assert_raise_with_message(Spreedly::PaymentRequiredError, "Your environment (R7lHscqcYkZeDGGbthKp6GKMu15) has not been activated for real transactions with real payment methods. If you're using a Test Gateway you can *ONLY* use Test payment methods - ( https://docs.spreedly.com/test-data). All other credit card numbers are considered real credit cards; real credit cards are not allowed when using a Test Gateway.") do
+    assert_raise_with_message(Spreedly::PaymentRequiredError, "Your environment (#{remote_test_environment_key}) has not been activated for real transactions with real payment methods. If you're using a Test Gateway you can *ONLY* use Test payment methods - ( https://docs.spreedly.com/test-data). All other credit card numbers are considered real credit cards; real credit cards are not allowed when using a Test Gateway.") do
       @environment.add_gateway(:wirecard)
     end
   end
-
 end

--- a/test/remote/remote_add_receiver_test.rb
+++ b/test/remote/remote_add_receiver_test.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class RemoteAddReceiverTest < Test::Unit::TestCase
-
   def setup
     @environment = Spreedly::Environment.new(remote_test_environment_key, remote_test_access_secret)
   end
@@ -13,7 +14,7 @@ class RemoteAddReceiverTest < Test::Unit::TestCase
   end
 
   def test_non_existent_receiver_type
-    assert_raise_with_message(Spreedly::UnexpectedResponseError, "Failed with 403 Forbidden") do
+    assert_raise_with_message(Spreedly::UnexpectedResponseError, 'Failed with 403 Forbidden') do
       @environment.add_receiver(:non_existent, nil)
     end
   end
@@ -26,14 +27,13 @@ class RemoteAddReceiverTest < Test::Unit::TestCase
 
   def test_add_test_receiver
     receiver = @environment.add_receiver(:test, 'http://spreedly-echo.herokuapp.com')
-    assert_equal "test", receiver.receiver_type
+    assert_equal 'test', receiver.receiver_type
     assert_equal 'http://spreedly-echo.herokuapp.com', receiver.hostnames
   end
 
   def test_need_active_account
-    assert_raise_with_message(Spreedly::PaymentRequiredError, "Your environment (R7lHscqcYkZeDGGbthKp6GKMu15) has not been activated for real transactions with real payment methods. If you're using a Test Gateway you can *ONLY* use Test payment methods - ( https://docs.spreedly.com/test-data). All other credit card numbers are considered real credit cards; real credit cards are not allowed when using a Test Gateway.") do
+    assert_raise_with_message(Spreedly::PaymentRequiredError, "Your environment (#{remote_test_environment_key}) has not been activated for real transactions with real payment methods. If you're using a Test Gateway you can *ONLY* use Test payment methods - ( https://docs.spreedly.com/test-data). All other credit card numbers are considered real credit cards; real credit cards are not allowed when using a Test Gateway.") do
       @environment.add_receiver(:braintree)
     end
   end
-
 end

--- a/test/unit/add_bank_account_test.rb
+++ b/test/unit/add_bank_account_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'unit/response_stubs/add_bank_account_stubs'
+
+class AddBankAccountTest < Test::Unit::TestCase
+  include AddBankAccountStubs
+
+  def setup
+    @environment = Spreedly::Environment.new('key', 'secret')
+  end
+
+  def test_successful_add_bank_account
+    t = add_bank_account_using(successful_add_bank_account_response)
+
+    assert_kind_of(Spreedly::AddPaymentMethod, t)
+    assert_kind_of(Spreedly::BankAccount, t.payment_method)
+
+    assert !t.retained?
+    assert t.succeeded?
+  end
+
+  private
+
+  def add_bank_account_using(response)
+    @environment.stubs(:raw_ssl_request).returns(response)
+    @environment.add_bank_account(ignored: 'Because response is stubbed')
+  end
+end

--- a/test/unit/response_stubs/add_bank_account_stubs.rb
+++ b/test/unit/response_stubs/add_bank_account_stubs.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module AddBankAccountStubs
+  def successful_add_bank_account_response
+    StubResponse.succeeded <<-XML
+      <transaction>
+        <token>CTRCfhdWDaJ5DBfUw2mbxUISux4</token>
+        <created_at type="dateTime">2015-12-02T20:47:13Z</created_at>
+        <updated_at type="dateTime">2015-12-02T20:47:13Z</updated_at>
+        <succeeded type="boolean">true</succeeded>
+        <transaction_type>AddPaymentMethod</transaction_type>
+        <retained type="boolean">false</retained>
+        <state>succeeded</state>
+        <message key="messages.transaction_succeeded">Succeeded!</message>
+        <payment_method>
+          <token>PsZvGrh0mIrmxzHQUNAscxyA7B1</token>
+          <created_at type="dateTime">2015-12-02T20:47:13Z</created_at>
+          <updated_at type="dateTime">2015-12-02T20:47:13Z</updated_at>
+          <email>joey@example.com</email>
+          <data>
+            <my_payment_method_identifier>448</my_payment_method_identifier>
+            <extra_stuff>
+              <some_other_things>Can be anything really</some_other_things>
+            </extra_stuff>
+          </data>
+          <storage_state>cached</storage_state>
+          <test type="boolean">true</test>
+          <full_name>Alessandro Stein</full_name>
+          <bank_name nil="true"></bank_name>
+          <account_type>checking</account_type>
+          <account_holder_type>personal</account_holder_type>
+          <routing_number_display_digits>021</routing_number_display_digits>
+          <account_number_display_digits>3210</account_number_display_digits>
+          <first_name>Alessandro</first_name>
+          <last_name>Stein</last_name>
+          <payment_method_type>bank_account</payment_method_type>
+          <errors>
+          </errors>
+          <routing_number>021*</routing_number>
+          <account_number>*3210</account_number>
+        </payment_method>
+      </transaction>
+    XML
+  end
+end


### PR DESCRIPTION
To use spreedly gem, we need an unrestricted environment key. This PR added the ability to create bank accounts following the Spreedly API Docs https://docs.spreedly.com/reference/api/v1/#create-bank-account